### PR TITLE
Feat: move packages to root

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ func main() {
         analysis := Analysis{Status: "DENIED"}
 
         // Create a new validator.Error instance.
-        validatorErr := kit.NewValidationError("analysis validation failed")
+        validatorErr := kit.NewValidatorError("analysis validation failed")
 
         // perform the validation
         if analysis.Status == "DENIED" && len(analysis.Description) < 5 {

--- a/context_key.go
+++ b/context_key.go
@@ -1,13 +1,16 @@
+// Package kit provides foundational utilities for building structured Go applications.
+// This file defines custom keys for storing values in the context.
+
 package kit
 
-// ContextKey defines custom keys for storing values in the context.
+// ContextKey represents a key used for storing values in the context.
 type ContextKey string
 
-// Predefined context keys
+// Predefined context keys for common use cases.
 const (
-	Logger              ContextKey = "kit.logger"
-	UserEmail           ContextKey = "kit.user_email"
-	UserCompany         ContextKey = "kit.user_company"
-	UserCompanyCategory ContextKey = "kit.user_company_category"
-	UserPermissions     ContextKey = "kit.user_permissions"
+	KeyLogger              ContextKey = "kit.logger"
+	KeyUserEmail           ContextKey = "kit.user_email"
+	KeyUserCompany         ContextKey = "kit.user_company"
+	KeyUserCompanyCategory ContextKey = "kit.user_company_category"
+	KeyUserPermissions     ContextKey = "kit.user_permissions"
 )

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,21 @@
+// Package kit is a foundational Go library designed to help developers build robust,
+// consistent, and maintainable applications. It provides utilities for structured logging,
+// validation, error handling, and middleware integration with the Fiber web framework.
+//
+// # Key Features:
+//
+//   - Validation: Provides a wrapper around `go-playground/validator`, supporting custom validation tags
+//     and localized error messages in Portuguese.
+//
+//   - Error Handling: Standardizes application errors with structured responses through `ResponseError`.
+//     Includes a Fiber-compatible error handler for seamless error processing.
+//
+//   - Logging: Leverages `slog` for structured, JSON-based logging with support for contextual attributes
+//     like request ID, user details, and response status.
+//
+//   - Middleware: Provides reusable middleware for Fiber, such as `LoggerMiddleware` for logging request
+//     and response data.
+//
+//   - Context Management: Defines `ContextKey` constants to facilitate storing and retrieving metadata
+//     (e.g., user info, logging context).
+package kit

--- a/error_handler.go
+++ b/error_handler.go
@@ -1,7 +1,7 @@
-// fiber_error_handler.go defines a custom error handler for the Fiber framework.
-// It maps domain-specific errors to structured JSON responses and logs them for observability.
+// Package kit provides foundational utilities for structured error handling in Go applications.
+// This file defines a custom error handler for Fiber.
 
-package responseerror
+package kit
 
 import (
 	"errors"
@@ -9,9 +9,10 @@ import (
 	"github.com/gofiber/fiber/v2"
 )
 
-// FiberErrorHandler creates a custom error handler for Fiber. It returns a Fiber.ErrorHandler
-// that maps *ResponseError errors to structured JSON responses with the appropriate HTTP status code.
-func FiberErrorHandler() fiber.ErrorHandler {
+// ErrorHandler returns a Fiber-compatible error handler that maps errors
+// to structured JSON responses. If the error is not a *ResponseError,
+// it wraps it in a generic UNKNOWN_ERROR with HTTP 500 status.
+func ErrorHandler() fiber.ErrorHandler {
 
 	// response represents the structure of the error payload sent to the client.
 	type response struct {
@@ -24,7 +25,7 @@ func FiberErrorHandler() fiber.ErrorHandler {
 		// Check if the error is a ResponseError, otherwise create a new generic UNKNOWN_ERROR 500 one.
 		var respError *ResponseError
 		if !errors.As(err, &respError) {
-			respError = New(err, "UNKNOWN_ERROR")
+			respError = NewResponseError(err, "UNKNOWN_ERROR")
 		}
 
 		// Send a JSON response with the appropriate HTTP status code and error details.

--- a/error_response.go
+++ b/error_response.go
@@ -1,13 +1,7 @@
-/*
-Package responseerror centralizes error handling and response management.
-It provides utilities to map domain-specific errors to structured HTTP responses
-and to create reusable error handlers for frameworks like Fiber.
+// Package kit provides structured error handling utilities.
+// This file defines the ResponseError struct for standardized error responses.
 
-Key Features:
-- Generate structured responses with detailed metadata (code, message, etc...).
-- Integrate with Fiber for seamless error handling and logging.
-*/
-package responseerror
+package kit
 
 import (
 	"fmt"
@@ -15,7 +9,6 @@ import (
 )
 
 // ResponseError represents a detailed error response with metadata.
-// It includes information such as code, HTTP status, and additional details.
 type ResponseError struct {
 	code       string            // Unique error code.
 	message    string            // Human-readable error message.
@@ -24,9 +17,9 @@ type ResponseError struct {
 	err        error             // Underlying error, if any.
 }
 
-// New creates a new ResponseError based on an error, a unique code, and an optional HTTP status.
-// If no status is provided, the default is HTTP 500 (Internal Server Error).
-func New(err error, code string, status ...int) *ResponseError {
+// NewResponseError creates a new ResponseError based on an error, a unique code, and an optional HTTP status.
+// If no status is provided, it defaults to HTTP 500.
+func NewResponseError(err error, code string, status ...int) *ResponseError {
 	if err == nil || code == "" {
 		return nil // Ensure valid inputs.
 	}

--- a/logger.go
+++ b/logger.go
@@ -1,20 +1,14 @@
-/*
-Package logger provides utilities for structured and context-aware logging in Go applications.
-It uses the `slog` library to output JSON-formatted logs with additional contextual information.
+// Package kit provides structured logging utilities for Go applications.
+// This file defines a logger using `slog` for JSON-based structured logs.
 
-Key Features:
-- JSON-based structured logging.
-- Support for adding contextual information such as service name, version, and request-specific details.
-- Configurable log levels to control verbosity.
-*/
-package logger
+package kit
 
 import (
 	"log/slog"
 	"os"
 )
 
-// New creates a new instance of a JSON-based `slog.Logger` with customizable attributes.
+// NewLogger creates a new instance of a JSON-based `slog.Logger` with customizable attributes.
 // It allows adding additional context (e.g., service name, version) to logs.
 //
 // Parameters:
@@ -23,7 +17,7 @@ import (
 //
 // Returns:
 // - A pointer to the configured `slog.Logger` instance.
-func New(level slog.Level, opts ...slog.Attr) *slog.Logger {
+func NewLogger(level slog.Level, opts ...slog.Attr) *slog.Logger {
 	// Configure a handler for JSON-formatted logs with source code information.
 	handler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
 		Level:     level,

--- a/validator.go
+++ b/validator.go
@@ -54,7 +54,7 @@ func NewValidator() (*Validator, error) {
 
 // Validate validates a struct and returns an *Error if any validation rules are violated.
 // If validation is successful, it returns nil.
-func (v Validator) Validate(s interface{}) *ValidationError {
+func (v Validator) Validate(s interface{}) *ValidatorError {
 	err := v.validate.Struct(s)
 	if err == nil {
 		return nil // No validation errors.
@@ -64,14 +64,14 @@ func (v Validator) Validate(s interface{}) *ValidationError {
 	if errors.As(err, &validationErrors) {
 		// Translate and sanitize validation error messages for readability.
 		translations := validationErrors.Translate(v.translator)
-		return &ValidationError{
+		return &ValidatorError{
 			message:     "validation failed",
 			validations: sanitizeKeys(translations),
 		}
 	}
 
 	// Return a generic error message if validation errors could not be translated.
-	return &ValidationError{
+	return &ValidatorError{
 		message: "Unknown validation error",
 	}
 }

--- a/validator.go
+++ b/validator.go
@@ -1,16 +1,7 @@
-/*
-Package validator provides utilities for struct validation in Go.
-It wraps the `go-playground/validator` library, adding support for
-error messages translated into Portuguese and offering structured
-and standardized validation error handling.
+// Package kit provides struct validation utilities using `go-playground/validator`.
+// This file defines a wrapper around the validator library with localized (pt_br) error messages.
 
-Key Features:
-- Simplified struct validation using tags.
-- Customizable tag names for error messages with `custom` tag.
-- Error messages with Portuguese translations.
-- Structured validation errors with easily readable error keys.
-*/
-package validator
+package kit
 
 import (
 	"errors"
@@ -31,9 +22,9 @@ type Validator struct {
 	translator ut.Translator       // Translator for localized error messages.
 }
 
-// New initializes a new Validator instance with Portuguese translations.
+// NewValidator initializes a new Validator instance with Portuguese translations.
 // It configures the validator with custom tag name parsing for error messages.
-func New() (*Validator, error) {
+func NewValidator() (*Validator, error) {
 	ptBR := pt_BR.New()                    // Load the Brazilian Portuguese locale.
 	uni := ut.New(ptBR)                    // Create a Universal Translator.
 	trans, _ := uni.GetTranslator("pt_br") // Get the Portuguese translator.
@@ -63,7 +54,7 @@ func New() (*Validator, error) {
 
 // Validate validates a struct and returns an *Error if any validation rules are violated.
 // If validation is successful, it returns nil.
-func (v Validator) Validate(s interface{}) *Error {
+func (v Validator) Validate(s interface{}) *ValidationError {
 	err := v.validate.Struct(s)
 	if err == nil {
 		return nil // No validation errors.
@@ -73,14 +64,14 @@ func (v Validator) Validate(s interface{}) *Error {
 	if errors.As(err, &validationErrors) {
 		// Translate and sanitize validation error messages for readability.
 		translations := validationErrors.Translate(v.translator)
-		return &Error{
+		return &ValidationError{
 			message:     "validation failed",
 			validations: sanitizeKeys(translations),
 		}
 	}
 
 	// Return a generic error message if validation errors could not be translated.
-	return &Error{
+	return &ValidationError{
 		message: "Unknown validation error",
 	}
 }

--- a/validator_error.go
+++ b/validator_error.go
@@ -1,4 +1,4 @@
-package validator
+package kit
 
 import (
 	"fmt"
@@ -10,17 +10,17 @@ type Validation struct {
 	Validation string
 }
 
-// Error represents a validation-specific error with additional context.
+// ValidationError represents a validation-specific error with additional context.
 // It includes a message, field-level validations, and an optional underlying error.
-type Error struct {
+type ValidationError struct {
 	message     string
 	validations map[string]string
 	err         error
 	tmpField    string
 }
 
-// NewError initializes a new validation error with the given message and optional validations.
-func NewError(message string, validations ...Validation) *Error {
+// NewValidationError initializes a new validation error with the given message and optional validations.
+func NewValidationError(message string, validations ...Validation) *ValidationError {
 	vs := make(map[string]string, len(validations))
 
 	if len(validations) > 0 {
@@ -29,32 +29,32 @@ func NewError(message string, validations ...Validation) *Error {
 		}
 	}
 
-	return &Error{
+	return &ValidationError{
 		message:     message,
 		validations: vs,
 	}
 }
 
 // Field sets the field name for the next validation error. This is useful for chaining validations.
-func (e *Error) Field(field string) *Error {
+func (e *ValidationError) Field(field string) *ValidationError {
 	e.tmpField = field
 	return e
 }
 
 // Err sets the validation message for the current field. This is useful for chaining validations.
-func (e *Error) Err(validation string) *Error {
+func (e *ValidationError) Err(validation string) *ValidationError {
 	e.validations[e.tmpField] = validation
 	return e
 }
 
 // AddValidation adds a field-level validation error to the error instance.
-func (e *Error) AddValidation(field, validation string) *Error {
+func (e *ValidationError) AddValidation(field, validation string) *ValidationError {
 	e.validations[field] = validation
 	return e
 }
 
 // AddValidations adds multiple field-level validation errors to the error instance.
-func (e *Error) AddValidations(validations ...Validation) *Error {
+func (e *ValidationError) AddValidations(validations ...Validation) *ValidationError {
 	for _, v := range validations {
 		e.validations[v.Field] = v.Validation
 	}
@@ -62,19 +62,19 @@ func (e *Error) AddValidations(validations ...Validation) *Error {
 }
 
 // HasValidations returns true if the error includes field-level validation errors.
-func (e *Error) HasValidations() bool {
+func (e *ValidationError) HasValidations() bool {
 	return len(e.validations) > 0
 }
 
 // Validations returns a map of field-level validation errors.
 // Each entry includes the field name and its associated validation message.
-func (e *Error) Validations() map[string]string {
+func (e *ValidationError) Validations() map[string]string {
 	return e.validations
 }
 
 // Error returns a string representation of the validation error message.
 // If there is an underlying error, it will be included in the returned string.
-func (e *Error) Error() string {
+func (e *ValidationError) Error() string {
 	if e.err == nil {
 		return e.message
 	}
@@ -83,12 +83,12 @@ func (e *Error) Error() string {
 
 // Wrap associates an underlying error with the validation error.
 // This is useful for adding context or chaining errors.
-func (e *Error) Wrap(err error) *Error {
+func (e *ValidationError) Wrap(err error) *ValidationError {
 	e.err = err
 	return e
 }
 
 // Unwrap exposes the underlying error for further inspection or processing.
-func (e *Error) Unwrap() error {
+func (e *ValidationError) Unwrap() error {
 	return e.err
 }

--- a/validator_error.go
+++ b/validator_error.go
@@ -10,17 +10,17 @@ type Validation struct {
 	Validation string
 }
 
-// ValidationError represents a validation-specific error with additional context.
+// ValidatorError represents a validation-specific error with additional context.
 // It includes a message, field-level validations, and an optional underlying error.
-type ValidationError struct {
+type ValidatorError struct {
 	message     string
 	validations map[string]string
 	err         error
 	tmpField    string
 }
 
-// NewValidationError initializes a new validation error with the given message and optional validations.
-func NewValidationError(message string, validations ...Validation) *ValidationError {
+// NewValidatorError initializes a new validator error with the given message and optional validations.
+func NewValidatorError(message string, validations ...Validation) *ValidatorError {
 	vs := make(map[string]string, len(validations))
 
 	if len(validations) > 0 {
@@ -29,32 +29,32 @@ func NewValidationError(message string, validations ...Validation) *ValidationEr
 		}
 	}
 
-	return &ValidationError{
+	return &ValidatorError{
 		message:     message,
 		validations: vs,
 	}
 }
 
 // Field sets the field name for the next validation error. This is useful for chaining validations.
-func (e *ValidationError) Field(field string) *ValidationError {
+func (e *ValidatorError) Field(field string) *ValidatorError {
 	e.tmpField = field
 	return e
 }
 
 // Err sets the validation message for the current field. This is useful for chaining validations.
-func (e *ValidationError) Err(validation string) *ValidationError {
+func (e *ValidatorError) Err(validation string) *ValidatorError {
 	e.validations[e.tmpField] = validation
 	return e
 }
 
 // AddValidation adds a field-level validation error to the error instance.
-func (e *ValidationError) AddValidation(field, validation string) *ValidationError {
+func (e *ValidatorError) AddValidation(field, validation string) *ValidatorError {
 	e.validations[field] = validation
 	return e
 }
 
 // AddValidations adds multiple field-level validation errors to the error instance.
-func (e *ValidationError) AddValidations(validations ...Validation) *ValidationError {
+func (e *ValidatorError) AddValidations(validations ...Validation) *ValidatorError {
 	for _, v := range validations {
 		e.validations[v.Field] = v.Validation
 	}
@@ -62,19 +62,19 @@ func (e *ValidationError) AddValidations(validations ...Validation) *ValidationE
 }
 
 // HasValidations returns true if the error includes field-level validation errors.
-func (e *ValidationError) HasValidations() bool {
+func (e *ValidatorError) HasValidations() bool {
 	return len(e.validations) > 0
 }
 
 // Validations returns a map of field-level validation errors.
 // Each entry includes the field name and its associated validation message.
-func (e *ValidationError) Validations() map[string]string {
+func (e *ValidatorError) Validations() map[string]string {
 	return e.validations
 }
 
 // Error returns a string representation of the validation error message.
 // If there is an underlying error, it will be included in the returned string.
-func (e *ValidationError) Error() string {
+func (e *ValidatorError) Error() string {
 	if e.err == nil {
 		return e.message
 	}
@@ -83,12 +83,12 @@ func (e *ValidationError) Error() string {
 
 // Wrap associates an underlying error with the validation error.
 // This is useful for adding context or chaining errors.
-func (e *ValidationError) Wrap(err error) *ValidationError {
+func (e *ValidatorError) Wrap(err error) *ValidatorError {
 	e.err = err
 	return e
 }
 
 // Unwrap exposes the underlying error for further inspection or processing.
-func (e *ValidationError) Unwrap() error {
+func (e *ValidatorError) Unwrap() error {
 	return e.err
 }


### PR DESCRIPTION
Esse PR move todos os pacotes (`logger`, `validator` e `responseerror`) para o root e atualiza documentação.
Agora todas as funcionalidades serão acessadas pelo package `kit`.